### PR TITLE
[고도화] 엔티티 코드 리팩토링 - `equals()`, `hashcode()`에서 필드 접근을 getter로 바꾸기

### DIFF
--- a/part2/project-board/src/main/java/com/fastcampus/projectboard/domain/article/Article.java
+++ b/part2/project-board/src/main/java/com/fastcampus/projectboard/domain/article/Article.java
@@ -59,11 +59,11 @@ public class Article extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof Article article)) return false;
-        return Objects.equals(id, article.id);
+        return Objects.equals(this.getId(), article.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/part2/project-board/src/main/java/com/fastcampus/projectboard/domain/article/ArticleComment.java
+++ b/part2/project-board/src/main/java/com/fastcampus/projectboard/domain/article/ArticleComment.java
@@ -48,12 +48,12 @@ public class ArticleComment extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof ArticleComment that)) return false;
-        return Objects.equals(id, that.id);
+        return Objects.equals(this.getId(), that.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 
 }

--- a/part2/project-board/src/main/java/com/fastcampus/projectboard/domain/user/UserAccount.java
+++ b/part2/project-board/src/main/java/com/fastcampus/projectboard/domain/user/UserAccount.java
@@ -55,12 +55,12 @@ public class UserAccount extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof UserAccount userAccount)) return false;
-        return userId != null && userId.equals(userAccount.userId);
+        return this.getUserId() != null && this.getUserId().equals(userAccount.getUserId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userId);
+        return Objects.hash(this.getUserId());
     }
 
 }


### PR DESCRIPTION
엔티티의 `equals()`, `hashcode()`가 값 비교를 하기 위해 필드 직접 접근하는 것을 getter 접근으로 바꾼다.
프록시 객체를 사용하는 하이버네이트의 지연 로딩을 고려하여, 값 비교를 제대로 수행하지 못하는 일이 없도록 한다.

This closes #56 