### PR TITLE
[고도화] MySQL -> PostgreSQL

### DIFF
--- a/part2/project-board/build.gradle
+++ b/part2/project-board/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	runtimeOnly 'org.postgresql:postgresql'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/part2/project-board/src/main/resources/application.yml
+++ b/part2/project-board/src/main/resources/application.yml
@@ -13,10 +13,9 @@ logging:
 
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/board
-    username: soono
-    password: soono
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:postgresql://localhost:5432/board
+    username: postgres
+    password: postgres
   jpa:
     open-in-view: false
     defer-datasource-initialization: true


### PR DESCRIPTION
JPA의 이점을 활용하여, 간단하게 프로젝트 DB를 MySQL -> PostgreSQL로 전환 성공.

This closes #54 