### PR TITLE
API 호출이 가능하도록 인증 설정 변경하기

### DIFF
--- a/part2/project-board/src/main/java/com/fastcampus/projectboard/config/SecurityConfig.java
+++ b/part2/project-board/src/main/java/com/fastcampus/projectboard/config/SecurityConfig.java
@@ -34,6 +34,7 @@ public class SecurityConfig {
                                 // 정적 리소스 설정
                                 .requestMatchers(PathRequest.toStaticResources().atCommonLocations())
                                 .permitAll()
+                                .requestMatchers("/api/**").permitAll()
                                 // 인증이 필요하지 않은 페이지 설정
                                 .requestMatchers(
                                         new AntPathRequestMatcher("/", HttpMethod.GET.name()),
@@ -51,6 +52,7 @@ public class SecurityConfig {
                                 .userService(oAuth2UserService)
                         )
                 )
+                .csrf(csrf -> csrf.ignoringRequestMatchers("/api/**"))
                 .build();
     }
 


### PR DESCRIPTION
이 `PR`은 외부 서비스(강의에서는 어드민 서비스)에서 원활하게 게시판 서비스의 데이터 api를 이용할 수 있도록 시큐리티 설정을 업데이트 한다.

This closes #86 